### PR TITLE
Availability monitoring for VmHostSlice

### DIFF
--- a/bin/monitor
+++ b/bin/monitor
@@ -8,7 +8,7 @@ resources = {}
 mutex = Mutex.new
 
 resource_scanner = Thread.new do
-  monitorable_resource_types = [VmHost, PostgresServer, Vm.where(~Sshable.where(id: Sequel[:vm][:id]).exists), MinioServer, GithubRunner]
+  monitorable_resource_types = [VmHost, PostgresServer, Vm.where(~Sshable.where(id: Sequel[:vm][:id]).exists), MinioServer, GithubRunner, VmHostSlice]
 
   loop do
     mutex.synchronize do


### PR DESCRIPTION
Adding support for availability monitoring, following the standard pattern for ./bin/monitor script.

The VmHostSlice checks for three conditions:
- if the slice systemd unit is available
- if the allowed cpus is set to what is configured in Clover
- if the slice partition type is 'root' which indicates exclusive cpuset