### PR TITLE
Updating E2E tests for VM slices

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -78,6 +78,9 @@ RSpec/SpecFilePathFormat:
   Exclude:
     - 'spec/routes/**/*.rb'
 
+RSpec/MultipleMemoizedHelpers:
+  Max: 6
+
 Sequel/IrreversibleMigration:
   Enabled: false
 

--- a/bin/ci
+++ b/bin/ci
@@ -18,6 +18,17 @@ def main(options)
     # on when the host is rebooted and can cause flaky issues for github runner tests.
     wait_until(encrypted_vms_st)
 
+    # Testing slices is not parallel with other tests as it requires a specific host state
+    Semaphore.incr(hetzner_server_st.id, "allow_slices")
+    wait_until(hetzner_server_st, "wait")
+
+    sliced_vms_st = Prog::Test::VmGroup.assemble(storage_encrypted: true, test_reboot: false, test_slices: true)
+    log(sliced_vms_st, "test_slices: true")
+    wait_until(sliced_vms_st)
+
+    Semaphore.incr(hetzner_server_st.id, "disallow_slices")
+    wait_until(hetzner_server_st, "wait")
+
     unencrypted_vms_st = Prog::Test::VmGroup.assemble(storage_encrypted: false, test_reboot: false)
     log(unencrypted_vms_st, "storage_encrypted: false")
     tests_to_wait << [unencrypted_vms_st, nil]
@@ -47,7 +58,7 @@ def wait_until(st, label = nil)
       st.destroy
       exit 1
     end
-    log(st.reload, "waiting #{label ? "for #{label}" : "exit"}")
+    log(st.reload, "waiting for #{label || "exit"}")
     sleep 10
   end
   log(st, "reached")

--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -245,6 +245,14 @@ class VmHost < Sequel::Model
     update(data_center: Hosting::Apis.pull_data_center(self))
   end
 
+  def allow_slices
+    update(accepts_slices: true)
+  end
+
+  def disallow_slices
+    update(accepts_slices: false)
+  end
+
   def set_server_name
     Hosting::Apis.set_server_name(self)
   end

--- a/model/vm_host_cpu.rb
+++ b/model/vm_host_cpu.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../model"
 
 class VmHostCpu < Sequel::Model

--- a/prog/test/hetzner_server.rb
+++ b/prog/test/hetzner_server.rb
@@ -3,7 +3,7 @@
 require_relative "../../lib/util"
 
 class Prog::Test::HetznerServer < Prog::Test::Base
-  semaphore :destroy
+  semaphore :destroy, :allow_slices, :disallow_slices
 
   def self.assemble(vm_host_id: nil)
     frame = if vm_host_id
@@ -121,7 +121,29 @@ class Prog::Test::HetznerServer < Prog::Test::Base
       hop_destroy
     end
 
+    when_allow_slices_set? do
+      hop_allow_slices
+    end
+
+    when_disallow_slices_set? do
+      hop_disallow_slices
+    end
+
     nap 15
+  end
+
+  label def allow_slices
+    vm_host.allow_slices
+    Semaphore.where(strand_id: strand.id, name: "allow_slices").destroy
+
+    hop_wait
+  end
+
+  label def disallow_slices
+    vm_host.disallow_slices
+    Semaphore.where(strand_id: strand.id, name: "disallow_slices").destroy
+
+    hop_wait
   end
 
   label def destroy

--- a/prog/test/vm_host_slices.rb
+++ b/prog/test/vm_host_slices.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "json"
+
+class Prog::Test::VmHostSlices < Prog::Test::Base
+  label def start
+    hop_verify_separation
+  end
+
+  label def verify_separation
+    if !(slice_standard.vm_host_cpus.map(&:cpu_number) & slice_burstable.vm_host_cpus.map(&:cpu_number)).empty?
+      fail_test "Standard and Burstable instances are sharing at least one cpu"
+    end
+
+    hop_verify_on_host
+  end
+
+  label def verify_on_host
+    [slice_burstable, slice_standard].each do |slice|
+      vm_host = slice.vm_host
+
+      # use the availability checks to verify if the slices are set up correctly
+      session = vm_host.sshable.start_fresh_session
+      reading = slice.check_pulse(
+        session: {ssh_session: session},
+        previous_pulse: {reading: "up", reading_rpt: 1, reading_chg: Time.now - 60}
+      )[:reading]
+      session.shutdown!
+      session.close
+
+      if reading == "down"
+        fail_test "Slice #{slice.id} is not setup correctly"
+      end
+    end
+
+    hop_finish
+  end
+
+  label def finish
+    pop "Verified VM Host Slices!"
+  end
+
+  label def failed
+    nap 15
+  end
+
+  def slice_standard
+    @slice_standard ||= VmHostSlice[frame["slice_standard"]]
+  end
+
+  def slice_burstable
+    @slice_burstable ||= VmHostSlice[frame["slice_burstable"]]
+  end
+end

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -63,7 +63,7 @@ class Prog::Vm::HostNexus < Prog::Base
       case st.prog
       when "LearnOs"
         os_version = st.exitval.fetch("os_version")
-        vm_host.update(os_version: os_version, accepts_slices: (os_version == "ubuntu-24.04"))
+        vm_host.update(os_version: os_version)
       when "LearnMemory"
         mem_gib = st.exitval.fetch("mem_gib")
         vm_host.update(total_mem_gib: mem_gib)

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -704,14 +704,6 @@ SERVICE
     r "systemctl restart #{q_vm}"
   end
 
-  def enable_bursting(slice_name, cpu_burst_percent_limit)
-    # Convert cpu_burst_percent limit to a usec value
-    # For now we assume that 100% == 100,000 usec, but that needs to be verified
-    cpu_burst_limit = cpu_burst_percent_limit * 1000
-
-    r "echo \"#{cpu_burst_limit}\" > /sys/fs/cgroup/#{slice_name}/#{q_vm_service}/cpu.max.burst"
-  end
-
   # Generate a MAC with the "local" (generated, non-manufacturer) bit
   # set and the multicast bit cleared in the first octet.
   #

--- a/spec/model/vm_host_slice_spec.rb
+++ b/spec/model/vm_host_slice_spec.rb
@@ -4,7 +4,7 @@ require_relative "../spec_helper"
 
 RSpec.describe VmHostSlice do
   subject(:vm_host_slice) do
-    VmHostSlice.create_with_id(
+    described_class.create_with_id(
       vm_host_id: vm_host.id,
       name: "standard",
       family: "standard",
@@ -13,8 +13,7 @@ RSpec.describe VmHostSlice do
       total_cpu_percent: 200,
       used_cpu_percent: 0,
       total_memory_gib: 4,
-      used_memory_gib: 0,
-      family: "standard"
+      used_memory_gib: 0
     )
   end
 

--- a/spec/model/vm_host_spec.rb
+++ b/spec/model/vm_host_spec.rb
@@ -389,4 +389,18 @@ RSpec.describe VmHost do
       expect(vh.spdk_cpu_count).to eq(4)
     end
   end
+
+  describe "#allow_slices" do
+    it "allows slices" do
+      expect(vh).to receive(:update).with(accepts_slices: true)
+      vh.allow_slices
+    end
+  end
+
+  describe "#disallow_slices" do
+    it "disallows slices" do
+      expect(vh).to receive(:update).with(accepts_slices: false)
+      vh.disallow_slices
+    end
+  end
 end

--- a/spec/model/vm_spec.rb
+++ b/spec/model/vm_spec.rb
@@ -80,12 +80,12 @@ RSpec.describe Vm do
 
     it "handles standard family" do
       vm.family = "standard"
-      expect(vm.can_share_slice?).to be_falsey
+      expect(vm.can_share_slice?).to be(false)
     end
 
     it "handles burstable family" do
       vm.family = "burstable"
-      expect(vm.can_share_slice?).to be_truthy
+      expect(vm.can_share_slice?).to be(true)
     end
   end
 

--- a/spec/prog/test/connected_subnets_spec.rb
+++ b/spec/prog/test/connected_subnets_spec.rb
@@ -37,8 +37,8 @@ RSpec.describe Prog::Test::ConnectedSubnets do
       expect(connected_subnets_test).to receive(:update_firewall_rules).with(ps_single, ps_multiple, config: :perform_tests_public_blocked)
       expect(connected_subnets_test).to receive(:update_firewall_rules).with(ps_multiple, ps_single, config: :perform_tests_public_blocked)
       expect(connected_subnets_test).to receive(:ps_multiple).and_return(ps_multiple).at_least(:once)
-      vm1 = instance_double(Vm, sshable: sshable, ephemeral_net4: NetAddr::IPv4Net.parse("0.0.0.0"), boot_image: "debian-12")
-      vm2 = instance_double(Vm, sshable: sshable, boot_image: "almalinux-9")
+      vm1 = instance_double(Vm, id: "1ae5f1c2-2f48-4eac-84e3-cfe35b2a9865", sshable: sshable, ephemeral_net4: NetAddr::IPv4Net.parse("0.0.0.0"), boot_image: "debian-12")
+      vm2 = instance_double(Vm, id: "3f2f4ed0-88b1-49c6-b66a-0d2ed4910ad0", sshable: sshable, boot_image: "almalinux-9")
       expect(ps_multiple).to receive(:vms).and_return([vm1, vm2]).at_least(:once)
       expect(sshable).to receive(:cmd).with("sudo yum install -y nc")
       expect(sshable).to receive(:cmd).with("sudo apt-get update && sudo apt-get install -y netcat-openbsd")
@@ -61,12 +61,12 @@ ExecStart=nc -l 8080 -6
       expect(sshable).to receive(:cmd).with("sudo systemctl daemon-reload")
       expect(sshable).to receive(:cmd).with("sudo systemctl enable listening_ipv4.service")
       expect(sshable).to receive(:cmd).with("sudo systemctl enable listening_ipv6.service")
-      expect(connected_subnets_test).to receive(:update_stack).with({"connected" => true})
+      expect(connected_subnets_test).to receive(:update_stack).with({"vm_to_be_connected_id" => vm1.id})
       expect { connected_subnets_test.start }.to nap(5)
     end
 
     it "hops to perform_tests_public_blocked" do
-      expect(connected_subnets_test).to receive(:frame).and_return({"connected" => true})
+      expect(connected_subnets_test).to receive(:frame).and_return({"vm_to_be_connected_id" => true})
       ps_multiple.strand.update(label: "wait")
       ps_single.strand.update(label: "wait")
       Semaphore.all.map(&:destroy)
@@ -252,6 +252,15 @@ ExecStart=nc -l 8080 -6
       vm2 = instance_double(Vm)
       expect(ps_multiple).to receive(:vms).and_return([vm1, vm2]).at_least(:once)
       expect(connected_subnets_test.vm_to_be_connected).to eq(vm1)
+    end
+
+    it "returns the vm to be connected when already connected" do
+      expect(connected_subnets_test).to receive(:ps_multiple).and_return(ps_multiple).at_least(:once)
+      vm1 = instance_double(Vm, id: "vm1")
+      vm2 = instance_double(Vm, id: "vm2")
+      expect(ps_multiple).to receive(:vms).and_return([vm1, vm2]).at_least(:once)
+      expect(connected_subnets_test).to receive(:frame).and_return({"vm_to_be_connected_id" => vm2.id})
+      expect(connected_subnets_test.vm_to_be_connected).to eq(vm2)
     end
   end
 

--- a/spec/prog/test/hetzner_server_spec.rb
+++ b/spec/prog/test/hetzner_server_spec.rb
@@ -147,8 +147,32 @@ RSpec.describe Prog::Test::HetznerServer do
       expect { hs_test.wait }.to hop("destroy")
     end
 
+    it "hops to allow_slices when signaled" do
+      expect(hs_test).to receive(:when_allow_slices_set?).and_yield
+      expect { hs_test.wait }.to hop("allow_slices")
+    end
+
+    it "hops to disallow_slices when signaled" do
+      expect(hs_test).to receive(:when_disallow_slices_set?).and_yield
+      expect { hs_test.wait }.to hop("disallow_slices")
+    end
+
     it "naps" do
       expect { hs_test.wait }.to nap(15)
+    end
+  end
+
+  describe "#allow_slices" do
+    it "allows slices" do
+      expect(vm_host).to receive(:allow_slices)
+      expect { hs_test.allow_slices }.to hop("wait")
+    end
+  end
+
+  describe "#disallow_slices" do
+    it "disallows slices" do
+      expect(vm_host).to receive(:disallow_slices)
+      expect { hs_test.disallow_slices }.to hop("wait")
     end
   end
 

--- a/spec/prog/test/vm_host_slices_spec.rb
+++ b/spec/prog/test/vm_host_slices_spec.rb
@@ -42,8 +42,7 @@ RSpec.describe Prog::Test::VmHostSlices do
 
   describe "#verify_separation" do
     it "fails the test if the slices are on the same CPUs" do
-      allow(vm_host_slices).to receive(:slice_standard).and_return(slice_standard)
-      allow(vm_host_slices).to receive(:slice_burstable).and_return(slice_burstable_same)
+      allow(vm_host_slices).to receive_messages(slice_standard: slice_standard, slice_burstable: slice_burstable_same)
       expect(vm_host_slices).to receive(:fail_test).with("Standard and Burstable instances are sharing at least one cpu")
 
       # we will call fail_test which will not actually hop
@@ -51,18 +50,14 @@ RSpec.describe Prog::Test::VmHostSlices do
     end
 
     it "hops to verify_on_host" do
-      allow(vm_host_slices).to receive(:slice_standard).and_return(slice_standard)
-      allow(vm_host_slices).to receive(:slice_burstable).and_return(slice_burstable)
-
+      allow(vm_host_slices).to receive_messages(slice_standard: slice_standard, slice_burstable: slice_burstable)
       expect { vm_host_slices.verify_separation }.to hop("verify_on_host")
     end
   end
 
   describe "#verify_on_host" do
     it "fails the test if the slice is not setup correctly" do
-      allow(vm_host_slices).to receive(:slice_standard).and_return(slice_standard)
-      allow(vm_host_slices).to receive(:slice_burstable).and_return(slice_burstable)
-
+      allow(vm_host_slices).to receive_messages(slice_standard: slice_standard, slice_burstable: slice_burstable)
       expect(slice_burstable).to receive(:vm_host).and_return(vm_host)
       expect(slice_burstable).to receive(:check_pulse).and_return({reading: "down"})
       expect(slice_standard).to receive(:vm_host).and_return(vm_host)
@@ -74,9 +69,7 @@ RSpec.describe Prog::Test::VmHostSlices do
     end
 
     it "hops to finish" do
-      allow(vm_host_slices).to receive(:slice_standard).and_return(slice_standard)
-      allow(vm_host_slices).to receive(:slice_burstable).and_return(slice_burstable)
-
+      allow(vm_host_slices).to receive_messages(slice_standard: slice_standard, slice_burstable: slice_burstable)
       expect(slice_burstable).to receive(:vm_host).and_return(vm_host)
       expect(slice_burstable).to receive(:check_pulse).and_return({reading: "up"})
       expect(slice_standard).to receive(:vm_host).and_return(vm_host)

--- a/spec/prog/test/vm_host_slices_spec.rb
+++ b/spec/prog/test/vm_host_slices_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require_relative "../../model/spec_helper"
+require "netaddr"
+
+RSpec.describe Prog::Test::VmHostSlices do
+  subject(:vm_host_slices) {
+    described_class.new(Strand.new(prog: "Test::VmHostSlices", label: "start"))
+  }
+
+  let(:slice_standard) {
+    instance_double(VmHostSlice,
+      id: "ff7539aa-e3e3-48d6-8a77-6e77cead900d",
+      allowed_cpus_cgroup: "2-3",
+      vm_host_cpus: [instance_double(VmHostCpu, cpu_number: 2), instance_double(VmHostCpu, cpu_number: 3)])
+  }
+
+  let(:slice_burstable) {
+    instance_double(VmHostSlice,
+      id: "115dd7bb-3081-4403-8b74-eda45e0e2fb1",
+      allowed_cpus_cgroup: "4-5",
+      vm_host_cpus: [instance_double(VmHostCpu, cpu_number: 4), instance_double(VmHostCpu, cpu_number: 5)])
+  }
+
+  let(:slice_burstable_same) {
+    instance_double(VmHostSlice,
+      id: "115dd7bb-3081-4403-8b74-eda45e0e2fb1",
+      allowed_cpus_cgroup: "2-3",
+      vm_host_cpus: [instance_double(VmHostCpu, cpu_number: 2), instance_double(VmHostCpu, cpu_number: 3)])
+  }
+
+  let(:vm_host) {
+    instance_double(VmHost,
+      sshable: instance_double(Sshable, start_fresh_session: instance_double(Net::SSH::Connection::Session, shutdown!: nil, close: nil)))
+  }
+
+  describe "#start" do
+    it "hops to verify_separation" do
+      expect { vm_host_slices.start }.to hop("verify_separation")
+    end
+  end
+
+  describe "#verify_separation" do
+    it "fails the test if the slices are on the same CPUs" do
+      allow(vm_host_slices).to receive(:slice_standard).and_return(slice_standard)
+      allow(vm_host_slices).to receive(:slice_burstable).and_return(slice_burstable_same)
+      expect(vm_host_slices).to receive(:fail_test).with("Standard and Burstable instances are sharing at least one cpu")
+
+      # we will call fail_test which will not actually hop
+      expect { vm_host_slices.verify_separation }.to hop("verify_on_host")
+    end
+
+    it "hops to verify_on_host" do
+      allow(vm_host_slices).to receive(:slice_standard).and_return(slice_standard)
+      allow(vm_host_slices).to receive(:slice_burstable).and_return(slice_burstable)
+
+      expect { vm_host_slices.verify_separation }.to hop("verify_on_host")
+    end
+  end
+
+  describe "#verify_on_host" do
+    it "fails the test if the slice is not setup correctly" do
+      allow(vm_host_slices).to receive(:slice_standard).and_return(slice_standard)
+      allow(vm_host_slices).to receive(:slice_burstable).and_return(slice_burstable)
+
+      expect(slice_burstable).to receive(:vm_host).and_return(vm_host)
+      expect(slice_burstable).to receive(:check_pulse).and_return({reading: "down"})
+      expect(slice_standard).to receive(:vm_host).and_return(vm_host)
+      expect(slice_standard).to receive(:check_pulse).and_return({reading: "up"})
+      expect(vm_host_slices).to receive(:fail_test).with("Slice #{slice_burstable.id} is not setup correctly")
+
+      # we will call fail_test which will not actually hop
+      expect { vm_host_slices.verify_on_host }.to hop("finish")
+    end
+
+    it "hops to finish" do
+      allow(vm_host_slices).to receive(:slice_standard).and_return(slice_standard)
+      allow(vm_host_slices).to receive(:slice_burstable).and_return(slice_burstable)
+
+      expect(slice_burstable).to receive(:vm_host).and_return(vm_host)
+      expect(slice_burstable).to receive(:check_pulse).and_return({reading: "up"})
+      expect(slice_standard).to receive(:vm_host).and_return(vm_host)
+      expect(slice_standard).to receive(:check_pulse).and_return({reading: "up"})
+
+      expect { vm_host_slices.verify_on_host }.to hop("finish")
+    end
+  end
+
+  describe "#finish" do
+    it "pops 'Verified VM Host Slices!'" do
+      expect(vm_host_slices).to receive(:pop).with("Verified VM Host Slices!")
+      vm_host_slices.finish
+    end
+  end
+
+  describe "#failed" do
+    it "naps for 15 seconds" do
+      expect { vm_host_slices.failed }.to nap(15)
+    end
+  end
+
+  describe "#slice_standard" do
+    it "returns the slice_standard" do
+      expect(vm_host_slices).to receive(:frame).and_return({"slice_standard" => slice_standard.id})
+      expect(VmHostSlice).to receive(:[]).with(slice_standard.id).and_return(slice_standard)
+      expect(vm_host_slices.slice_standard).to eq(slice_standard)
+    end
+  end
+
+  describe "#slice_burstable" do
+    it "returns the slice_burstable" do
+      expect(vm_host_slices).to receive(:frame).and_return({"slice_burstable" => slice_burstable.id})
+      expect(VmHostSlice).to receive(:[]).with(slice_burstable.id).and_return(slice_burstable)
+      expect(vm_host_slices.slice_burstable).to eq(slice_burstable)
+    end
+  end
+end

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe Prog::Vm::HostNexus do
     it "updates the vm_host record from the finished programs" do
       expect(nx).to receive(:leaf?).and_return(true)
       expect(vm_host).to receive(:update).with(total_mem_gib: 1)
-      expect(vm_host).to receive(:update).with(os_version: "ubuntu-22.04", accepts_slices: false)
+      expect(vm_host).to receive(:update).with(os_version: "ubuntu-22.04")
       expect(vm_host).to receive(:update).with(arch: "arm64", total_cores: 4, total_cpus: 5, total_dies: 3, total_sockets: 2)
       expect(nx).to receive(:reap).and_return([
         instance_double(Strand, prog: "LearnMemory", exitval: {"mem_gib" => 1}),

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -23,8 +23,7 @@ RSpec.describe Prog::Vm::HostNexus do
 
   before do
     allow(nx).to receive_messages(vm_host: vm_host, sshable: sshable)
-    allow(vm_host).to receive(:vms).and_return(vms)
-    allow(vm_host).to receive(:vm_host_slices).and_return(vm_host_slices)
+    allow(vm_host).to receive_messages(vms: vms, vm_host_slices: vm_host_slices)
   end
 
   describe ".assemble" do

--- a/spec/scheduling/allocator_spec.rb
+++ b/spec/scheduling/allocator_spec.rb
@@ -20,9 +20,11 @@ RSpec.describe Al do
   }
 
   before do
-    allow(project).to receive(:get_ff_use_slices_for_allocation).and_return(nil)
-    allow(project).to receive(:get_ff_enable_diagnostics).and_return(nil)
-    allow(project).to receive(:get_ff_vm_public_ssh_keys).and_return(nil)
+    allow(project).to receive_messages(
+      get_ff_use_slices_for_allocation: nil,
+      get_ff_enable_diagnostics: nil,
+      get_ff_vm_public_ssh_keys: nil
+    )
     allow(vm).to receive_messages(projects: [project])
   end
 

--- a/spec/thawed_mock.rb
+++ b/spec/thawed_mock.rb
@@ -79,6 +79,7 @@ module ThawedMock
   allow_mocking(VmHost, :[])
   allow_mocking(Vm, :[], :where)
   allow_mocking(VmPool, :[], :where)
+  allow_mocking(VmHostSlice, :[])
 
   # Progs
   allow_mocking(Prog::Ai::InferenceEndpointNexus, :assemble, :model_for_id)


### PR DESCRIPTION
Added a set of tests to verify creation and placing of VMs in VmHostSlice. The new tests create the same set of VMs as regular tests, but with slice creation enabled for the project. We add Prog::Test::VmHostSlices to verify that the slice objects were created correctly.